### PR TITLE
Convert mcp-alchemy to package

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Works with PostgreSQL, MySQL, MariaDB, SQLite, Oracle, MS SQL Server and a host 
       id: INTEGER, primary key, autoincrement
       email: VARCHAR(255), nullable
       created_at: DATETIME
-      
+
       Relationships:
         id -> orders.user_id
   ```
@@ -83,8 +83,8 @@ Add to your `claude_desktop_config.json`:
 {
   "mcpServers": {
     "my_database": {
-      "command": "uv",
-      "args": ["--directory", "/path/to/mcp-alchemy", "run", "server.py"],
+      "command": "uvx",
+      "args": ["--from", "git+https://github.com/runekaagaard/mcp-alchemy", "mcp-alchemy"],
       "env": {
         "DB_URL": "mysql+pymysql://root:secret@localhost/databasename",
       }
@@ -162,4 +162,4 @@ The goal is to make database interaction with Claude even better, and your insig
 
 ## License
 
-Mozilla Public License Version 2.0 
+Mozilla Public License Version 2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,8 @@ dependencies = [
     "pymysql>=1.1.1",
     "sqlalchemy>=2.0.36",
 ]
+[project.scripts]
+mcp-alchemy = "server:main"
+
+[tool.uv]
+package = true

--- a/server.py
+++ b/server.py
@@ -163,5 +163,10 @@ def execute_query(query: str, params: Optional[dict] = None) -> str:
     except Exception as e:
         return f"Error: {str(e)}"
 
-if __name__ == "__main__":
+
+def main():
     mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.12"
 
 [[package]]
@@ -182,7 +183,7 @@ cli = [
 [[package]]
 name = "mcp-alchemy"
 version = "0.1.0"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },
     { name = "psycopg2-binary" },
@@ -235,6 +236,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/ac/5b1ea50fc08a9df82de7e1771537557f07c2632231bbab652c7e22597908/psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:bb89f0a835bcfc1d42ccd5f41f04870c1b936d8507c6df12b7737febc40f0909", size = 2822712 },
     { url = "https://files.pythonhosted.org/packages/c4/fc/504d4503b2abc4570fac3ca56eb8fed5e437bf9c9ef13f36b6621db8ef00/psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f0c2d907a1e102526dd2986df638343388b94c33860ff3bbe1384130828714b1", size = 2920155 },
     { url = "https://files.pythonhosted.org/packages/b2/d1/323581e9273ad2c0dbd1902f3fb50c441da86e894b6e25a73c3fda32c57e/psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f8157bed2f51db683f31306aa497311b560f2265998122abe1dce6428bd86567", size = 2959356 },
+    { url = "https://files.pythonhosted.org/packages/08/50/d13ea0a054189ae1bc21af1d85b6f8bb9bbc5572991055d70ad9006fe2d6/psycopg2_binary-2.9.10-cp313-cp313-win_amd64.whl", hash = "sha256:27422aa5f11fbcd9b18da48373eb67081243662f9b46e6fd07c3eb46e4535142", size = 2569224 },
 ]
 
 [[package]]


### PR DESCRIPTION
Make it possible to run the server without extra step : git checkout.

`uv` tool is capable of installing a package from git URL. The only missing thing - it must be a package with entry point defined.