### PR TITLE
Dependencies: Relax version of `mcp` package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "mcp[cli]===1.2.0rc1",
+    "mcp[cli]>=1.2.0rc1",
     "psycopg2-binary>=2.9.10",
     "pymysql>=1.1.1",
     "sqlalchemy>=2.0.36",


### PR DESCRIPTION
Hi there,

thanks a stack for concieving this nice package. We had trouble installing it in parallel with `pg-mcp`: This patch specifically fixes a minor dependency flaw, while other suggestions have been submitted per GH-9.

With kind regards,
Andreas.
