### PR TITLE
Add support for Vertica

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Let Claude be your database expert! MCP Alchemy connects Claude Desktop directly
 - Analyze large datasets and create reports
 - Claude Desktop Can analyse and create artifacts for very large datasets using [claude-local-files](https://github.com/runekaagaard/claude-local-files).
 
-Works with PostgreSQL, MySQL, MariaDB, SQLite, Oracle, MS SQL Server, CrateDB,
+Works with PostgreSQL, MySQL, MariaDB, SQLite, Oracle, MS SQL Server, CrateDB, Vertica,
 and a host of other [SQLAlchemy-compatible](https://docs.sqlalchemy.org/en/20/dialects/) databases.
 
 ![MCP Alchemy in action](https://raw.githubusercontent.com/runekaagaard/mcp-alchemy/refs/heads/main/screenshot.png)
@@ -132,11 +132,37 @@ cached causing uv to raise a versioning error. Restarting the MCP client once ag
 For connecting to CrateDB Cloud, use a URL like
 `crate://user:password@example.aks1.westeurope.azure.cratedb.net:4200?ssl=true`.
 
+### Vertica
+```json
+{
+  "mcpServers": {
+    "my_vertica_db": {
+      "command": "uvx",
+      "args": ["--from", "mcp-alchemy==2025.5.2.210242", "--with", "vertica-python",
+               "--refresh-package", "mcp-alchemy", "mcp-alchemy"],
+      "env": {
+        "DB_URL": "vertica+vertica_python://user:password@localhost:5433/dbname",
+        "DB_ENGINE_OPTIONS": "{\"connect_args\": {\"ssl\": false}}"
+      }
+    }
+  }
+}
+```
+
 ## Environment Variables
 
 - `DB_URL`: SQLAlchemy [database URL](https://docs.sqlalchemy.org/en/20/core/engines.html#database-urls) (required)
 - `CLAUDE_LOCAL_FILES_PATH`: Directory for full result sets (optional)
 - `EXECUTE_QUERY_MAX_CHARS`: Maximum output length (optional, default 4000)
+- `DB_ENGINE_OPTIONS`: JSON string containing additional SQLAlchemy engine options (optional)
+  ```json
+  {
+    "connect_args": {"ssl": false},  // Vertica example
+    "isolation_level": null,         // Disable isolation level
+    "pool_size": 5                   // Custom pool size
+  }
+  ```
+  Note: When `DB_ENGINE_OPTIONS` is not set, the default behavior includes `isolation_level='AUTOCOMMIT'` for backward compatibility.
 
 ## API
 

--- a/mcp_alchemy/server.py
+++ b/mcp_alchemy/server.py
@@ -16,7 +16,23 @@ def tests_set_global(k, v):
 
 def get_engine(readonly=True):
     connection_string = os.environ['DB_URL']
-    return create_engine(connection_string, isolation_level='AUTOCOMMIT', execution_options={'readonly': readonly})
+    # Get base engine options
+    engine_options = {
+        'isolation_level': 'AUTOCOMMIT',
+        'execution_options': {'readonly': readonly}
+    }
+    
+    db_engine_options = os.environ.get('DB_ENGINE_OPTIONS')
+    
+    if db_engine_options:
+        try:
+            custom_options = json.loads(db_engine_options)
+            engine_options.update(custom_options)
+            
+        except json.JSONDecodeError:
+            get_logger(__name__).warning("Invalid DB_ENGINE_OPTIONS JSON, ignoring")
+        
+    return create_engine(connection_string, **engine_options)
 
 def get_db_info():
     engine = get_engine(readonly=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-alchemy"
-version = "2025.5.2.210242"
+version = "2025.6.17.110500"
 description = "A MCP server that connects to your database"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Vertica is supported by SQL Alchemy but not wih the official release of MCP Alchemy, reason for that is that some of the parameters should be injected differently than by default available today,
with this version - users can update the parameters to create the engine, which can open for more than just Vertica,
also added example of Vertica and documentation for the parameter.