### PR TITLE
Support for stateless remote mcp transport using sse and streamable http

### DIFF
--- a/mcp_alchemy/database_context.py
+++ b/mcp_alchemy/database_context.py
@@ -1,0 +1,87 @@
+import time
+
+from mcp.server.fastmcp.utilities.logging import get_logger
+from sqlalchemy import Connection, create_engine, text, inspect
+
+logger = get_logger(__name__)
+
+DISPOSE_UNUSED_CONNECTION_INTERVAL = 60 * 10
+
+
+class DatabaseContext:
+    connection: Connection | None
+
+    def __init__(self, db_url: str, db_engine_options: dict):
+        self._db_url = db_url
+        self._db_engine_options = db_engine_options
+
+        self.connection = self._get_connection()
+        self.last_used = 0
+
+    def mark_as_used(self):
+        self.last_used = time.time()
+
+    def should_close(self):
+        now = time.time()
+
+        should_close_connection = now - self.last_used >= DISPOSE_UNUSED_CONNECTION_INTERVAL
+
+        return should_close_connection
+
+    def _get_connection(self) -> Connection:
+        try:
+            logger.info(f"Creating connection to: {self._db_url}, Options: {self._db_engine_options}")
+
+            engine = create_engine(self._db_url, **self._db_engine_options)
+            connection = engine.connect()
+
+            logger.info("Connected")
+
+            return connection
+
+        except Exception as ex:
+            logger.error(f"Failed to get database connection, Error: {ex}")
+
+            raise ex
+
+    def is_connected(self):
+        return self.connection and not self.connection.closed and self.connection.connection.is_valid
+
+    def execute_query(self, query, params):
+        cursor = self.connection.execute(text(query), params)
+
+        return cursor
+
+    def get_tables(self, filter_query: str | None = None) -> list[str]:
+        inspector = inspect(self.connection)
+
+        all_tables = inspector.get_table_names()
+
+        filtered_tables = [
+            table_name
+            for table_name in all_tables
+            if filter_query is None or filter_query in table_name
+        ]
+
+        return filtered_tables
+
+    def get_schema_details(self, table_names: list[str]):
+        inspector = inspect(self.connection)
+        table_schema_list = []
+
+        for table_name in table_names:
+            columns = inspector.get_columns(table_name)
+            foreign_keys = inspector.get_foreign_keys(table_name)
+            pk_constraint = inspector.get_pk_constraint(table_name)
+            primary_keys = set(pk_constraint["constrained_columns"])
+
+            data = {
+                "name": table_name,
+                "columns": columns,
+                "foreign_keys": foreign_keys,
+                "primary_keys": primary_keys
+            }
+
+            table_schema_list.append(data)
+
+        return table_schema_list

--- a/mcp_alchemy/mcp_args.py
+++ b/mcp_alchemy/mcp_args.py
@@ -15,6 +15,7 @@ class MCPServerArguments:
     transport: str
     debug: bool
     close_unused_connections_interval: int
+    stateless_http: bool
 
     def __init__(self,
                  name: str = DEFAULT_MCP_SERVER_NAME,
@@ -31,6 +32,7 @@ class MCPServerArguments:
         self.transport = transport
         self.debug = debug
         self.close_unused_connections_interval = close_unused_connections_interval
+        self.stateless_http = self.transport == "streamable-http"
 
     @staticmethod
     def load(is_entrypoint: bool):

--- a/mcp_alchemy/mcp_args.py
+++ b/mcp_alchemy/mcp_args.py
@@ -1,0 +1,89 @@
+import argparse
+
+DEFAULT_MCP_SERVER_NAME = "MCP Alchemy"
+DEFAULT_MCP_SERVER_HOST = "127.0.0.1"
+DEFAULT_MCP_SERVER_PORT = 8000
+DEFAULT_MCP_SERVER_TRANSPORT = "stdio"
+DEFAULT_MCP_SERVER_DEBUG = False
+DEFAULT_MCP_SERVER_CLOSE_UNUSED_INTERVAL = 600
+
+
+class MCPServerArguments:
+    name: str
+    host: str
+    port: int
+    transport: str
+    debug: bool
+    close_unused_connections_interval: int
+
+    def __init__(self,
+                 name: str = DEFAULT_MCP_SERVER_NAME,
+                 host: str = DEFAULT_MCP_SERVER_HOST,
+                 port: int = DEFAULT_MCP_SERVER_PORT,
+                 transport: str = DEFAULT_MCP_SERVER_TRANSPORT,
+                 debug: bool = DEFAULT_MCP_SERVER_DEBUG,
+                 close_unused_connections_interval: int = DEFAULT_MCP_SERVER_CLOSE_UNUSED_INTERVAL
+        ):
+
+        self.name = name
+        self.host = host
+        self.port = port
+        self.transport = transport
+        self.debug = debug
+        self.close_unused_connections_interval = close_unused_connections_interval
+
+    @staticmethod
+    def load(is_entrypoint: bool):
+        if is_entrypoint:
+            p = argparse.ArgumentParser(description="Run MCP Alchemy")
+
+            # Name for the MCP Server
+            p.add_argument(
+                "--name",
+                default=DEFAULT_MCP_SERVER_NAME
+            )
+
+            # Host for the MCP Server
+            # Relevant for SSE / Streamable-HTTP,
+            # If not set for those transport layers - will be accessible only from localhost
+            p.add_argument(
+                "--host",
+                default=DEFAULT_MCP_SERVER_HOST
+            )
+
+            # Port for the MCP Server, relevant for SSE / Streamable-HTTP
+            p.add_argument(
+                "--port",
+                type=int,
+                default=DEFAULT_MCP_SERVER_PORT
+            )
+
+            # Which transport layer to use (stdio, sse, streamable-http)
+            p.add_argument(
+                "--transport",
+                default=DEFAULT_MCP_SERVER_TRANSPORT,
+                choices=["stdio", "sse", "streamable-http"]
+            )
+
+            # Run with debug logs
+            p.add_argument(
+                "--debug",
+                type=bool,
+                default=DEFAULT_MCP_SERVER_DEBUG
+            )
+
+            # Interval in seconds to check if DB connection is not being used
+            p.add_argument(
+                "--close-unused-connections-interval",
+                type=int,
+                default=DEFAULT_MCP_SERVER_CLOSE_UNUSED_INTERVAL
+            )
+
+            args = p.parse_args()
+
+            mcp_args = MCPServerArguments(args.name, args.host, args.port, args.transport, args.debug, args.close_unused_connections_interval)
+
+        else:
+            mcp_args = MCPServerArguments()
+
+        return mcp_args

--- a/mcp_alchemy/mcp_tools.py
+++ b/mcp_alchemy/mcp_tools.py
@@ -1,0 +1,34 @@
+import json
+from enum import StrEnum
+
+
+class MCPTool(StrEnum):
+    all_table_names = "all_table_names"
+    filter_table_names = "filter_table_names"
+    schema_definitions = "schema_definitions"
+    execute_query = "execute_query"
+
+    def to_description(self) -> str | None:
+        description: str | None = None
+
+        if self == MCPTool.all_table_names:
+            description = "Return all table names in the database separated by comma."
+
+        elif self == MCPTool.filter_table_names:
+            description = "Return all table names in the database containing the substring 'q' separated by comma."
+
+        elif self == MCPTool.schema_definitions:
+            description = "Returns schema and relation information for the given tables."
+
+        elif self == MCPTool.execute_query:
+            description = (
+                "Execute a SQL query and return results in a readable format.\n"
+                "Results will be truncated after characters as configured in the parameter.\n"
+                "Claude Desktop may fetch the full result set via an url for analysis and artifacts (Optional - using CLAUDE_LOCAL_FILES_PATH).\n"
+                "IMPORTANT: \n"
+                "1. You MUST use the params parameter for query parameter substitution to prevent SQL injection.\n"
+                "\tExample: 'WHERE id = :id' with params={'id': 123}\n"
+                "2. Direct string concatenation is a serious security risk."
+            )
+
+        return description

--- a/mcp_alchemy/request_context.py
+++ b/mcp_alchemy/request_context.py
@@ -95,7 +95,7 @@ class RequestContext:
 
         db_context: DatabaseContext | None = None
 
-        if db_context in DATABASE_CONTEXT_LIST:
+        if connection_id in DATABASE_CONTEXT_LIST:
             db_context = DATABASE_CONTEXT_LIST[connection_id]
 
         if db_context is None or not db_context.is_connected():

--- a/mcp_alchemy/request_context.py
+++ b/mcp_alchemy/request_context.py
@@ -1,0 +1,149 @@
+import hashlib
+import json
+import os
+from time import sleep
+from typing import Any
+
+from mcp.server.fastmcp import Context
+from mcp.server.fastmcp.utilities.logging import get_logger
+from starlette.requests import Request
+
+from mcp_alchemy.database_context import DatabaseContext
+
+logger = get_logger(__name__)
+
+DISPOSE_UNUSED_CONNECTIONS_INTERVAL = 60
+
+PARAM_DB_URL = "DB_URL"
+PARAM_DB_ENGINE_OPTIONS = "DB_ENGINE_OPTIONS"
+PARAM_EXECUTE_QUERY_MAX_CHARS = "EXECUTE_QUERY_MAX_CHARS"
+PARAM_CLAUDE_LOCAL_FILES_PATH = "CLAUDE_LOCAL_FILES_PATH"
+
+SUPPORTED_ENV_VARS = [
+    PARAM_DB_URL,
+    PARAM_DB_ENGINE_OPTIONS,
+    PARAM_EXECUTE_QUERY_MAX_CHARS,
+    PARAM_CLAUDE_LOCAL_FILES_PATH
+]
+
+SUPPORTED_HEADERS = {
+    f"x-{env_var.replace('_', '-')}".lower(): env_var
+    for env_var in SUPPORTED_ENV_VARS
+}
+
+DEFAULT_DB_ENGINE_OPTIONS = "{}"
+DEFAULT_EXECUTE_QUERY_MAX_CHARS = "4000"
+
+DEFAULT_OPTIONS = {
+    'isolation_level': 'AUTOCOMMIT',
+    # Test connections before use (handles MySQL 8hr timeout, network drops)
+    'pool_pre_ping': True,
+    # Keep minimal connections (MCP typically handles one request at a time)
+    'pool_size': 1,
+    # Allow temporary burst capacity for edge cases
+    'max_overflow': 2,
+    # Force refresh connections older than 1hr (well under MySQL's 8hr default)
+    'pool_recycle': 3600
+}
+
+DATABASE_CONTEXT_LIST: dict[str, DatabaseContext] = {}
+
+
+class RequestContext:
+    db_url: str
+    db_engine_options: dict
+    execute_query_max_chars: int
+    claude_local_files_path: str | None
+    request: Request | None
+    context: Context | None
+    db_context: DatabaseContext | None
+
+    def __init__(self, ctx: Context | None = None):
+        self.context = ctx
+        self.request = ctx.request_context.request if ctx and ctx.request_context else None
+
+        if self.request is None:
+            data = {
+                str(key).upper(): os.environ[key]
+                for key in os.environ
+            }
+
+        else:
+            data = {
+                self.header_key_to_env_var_format(key): self.request.headers[key]
+                for key in self.request.headers
+            }
+
+        self.db_url = data.get(PARAM_DB_URL)
+
+        if self.db_url is None:
+            raise ValueError("DB_URL cannot be None")
+
+        self.execute_query_max_chars = int(data.get(PARAM_EXECUTE_QUERY_MAX_CHARS, DEFAULT_EXECUTE_QUERY_MAX_CHARS))
+        self.claude_local_files_path = data.get(PARAM_CLAUDE_LOCAL_FILES_PATH)
+
+        db_engine_options = data.get(PARAM_DB_ENGINE_OPTIONS, DEFAULT_DB_ENGINE_OPTIONS)
+
+        user_options = json.loads(db_engine_options)
+
+        db_options = DEFAULT_OPTIONS.copy()
+        db_options.update(user_options)
+
+        self.db_engine_options = db_options
+
+        connection_id = str(hashlib.md5(self.db_url.encode()).hexdigest())
+
+        db_context: DatabaseContext | None = None
+
+        if db_context in DATABASE_CONTEXT_LIST:
+            db_context = DATABASE_CONTEXT_LIST[connection_id]
+
+        if db_context is None or not db_context.is_connected():
+            db_context = DatabaseContext(self.db_url, self.db_engine_options)
+
+        self.db_context = db_context
+
+        self.db_context.mark_as_used()
+
+    @staticmethod
+    def header_key_to_env_var_format(key: str) -> str:
+        key = key.lower()
+
+        if key.startswith("x-"):
+            key  = SUPPORTED_HEADERS.get(key)
+
+        return key.upper()
+
+    def get_parameter(self, key: str, value: Any | None):
+        if self.request is not None:
+            if value is None:
+                value = self.request.query_params.get(key)
+
+            if value is None:
+                value = self.request.headers.get(key)
+
+        return value
+
+    @staticmethod
+    def load(ctx: Context | None = None):
+        return RequestContext(ctx)
+
+    @staticmethod
+    def dispose_unused_connections():
+        while True:
+            closed_connections = []
+            for connection_id in DATABASE_CONTEXT_LIST:
+                db_context = DATABASE_CONTEXT_LIST[connection_id]
+
+                if db_context.should_close():
+                    db_context.connection.close()
+                    closed_connections.append(connection_id)
+
+            for closed_connection in closed_connections:
+                del DATABASE_CONTEXT_LIST[closed_connection]
+
+            sleep(DISPOSE_UNUSED_CONNECTIONS_INTERVAL)
+
+
+
+

--- a/mcp_alchemy/response_formatter.py
+++ b/mcp_alchemy/response_formatter.py
@@ -1,0 +1,204 @@
+import hashlib
+import json
+import os
+from datetime import datetime, date
+
+from mcp.server.fastmcp.utilities.logging import get_logger
+
+from mcp_alchemy.request_context import RequestContext
+
+SHOW_KEY_ONLY = {"nullable", "autoincrement"}
+SAVED_CLAUDE_FILE_NAME_PLACEHOLDER = "[FILE_NAME]"
+SAVED_CLAUDE_RESULT = (
+    f"Full result set url: https://cdn.jsdelivr.net/pyodide/claude-local-files/{SAVED_CLAUDE_FILE_NAME_PLACEHOLDER}"
+    " (format: [[row1_value1, row1_value2, ...], [row2_value1, row2_value2, ...], ...]])"
+    " (ALWAYS prefer fetching this url in artifacts instead of hardcoding the values if at all possible)"
+)
+
+logger = get_logger(__name__)
+
+
+class ResponseFormatter:
+    _request_context: RequestContext
+
+    def __init__(self, request_context: RequestContext):
+        self._request_context = request_context
+
+    def get_schema_list_response(self, table_names):
+        table_names = self._request_context.get_parameter("table_names", table_names)
+
+        logger.info(f"Retrieving schema definition for table names: '{table_names}'")
+
+        table_schema_list = self._request_context.db_context.get_schema_details(table_names)
+
+        all_schema_response = [
+            self._format_single_schema_response(table_schema)
+            for table_schema in table_schema_list
+        ]
+
+        logger.info(f"{len(table_schema_list):,.0f} schema definitions found for tables '{table_names}'")
+
+        response = "\n".join(all_schema_response)
+
+        return response
+
+    def get_execute_query_response(self, query, params):
+        query = self._request_context.get_parameter("query", query)
+        params = self._request_context.get_parameter("params", params)
+
+        claude_local_files_path = self._request_context.claude_local_files_path
+        execute_query_max_chars = self._request_context.execute_query_max_chars
+
+        try:
+            logger.info(f"Executing query '{query}', params: {params}")
+
+            cursor = self._request_context.db_context.execute_query(query, params)
+
+            if not cursor.returns_rows:
+                message = f"Success: {cursor.rowcount} rows affected"
+
+            else:
+                output, full_results = self._format_query_execution_result(cursor, claude_local_files_path, execute_query_max_chars)
+
+                if full_results_message := self._save_full_results(full_results, claude_local_files_path):
+                    output.append(full_results_message)
+
+                message = "\n".join(output)
+
+            logger.info(message)
+
+            return message
+
+        except Exception as e:
+            message = f"Error: {str(e)}"
+
+            logger.error(message)
+
+            return message
+
+    def _format_query_execution_result(self, cursor, claude_local_files_path, execute_query_max_chars):
+        """Format rows in a clean vertical format"""
+        output, full_results = [], []
+        size, i, did_truncate = 0, 0, False
+
+        i = 0
+        while row := cursor.fetchone():
+            i += 1
+            if claude_local_files_path:
+                full_results.append(row)
+
+            if did_truncate:
+                continue
+
+            sub_result = [f"{i}. row"]
+
+            for col, val in zip(cursor.keys(), row):
+                sub_result.append(f"{col}: {self._format_value(val)}")
+
+            sub_result.append("")
+
+            size += sum(len(x) + 1 for x in sub_result)  # +1 is for line endings
+
+            if size > execute_query_max_chars:
+                did_truncate = True
+                if not claude_local_files_path:
+                    break
+            else:
+                output.extend(sub_result)
+
+        if i == 0:
+            return ["No rows returned"], full_results
+
+        elif did_truncate:
+            if claude_local_files_path:
+                output.append(f"Result: {i} rows (output truncated)")
+            else:
+                output.append(f"Result: showing first {i - 1} rows (output truncated)")
+
+            return output, full_results
+
+        else:
+            output.append(f"Result: {i} rows")
+
+            return output, full_results
+
+    def _save_full_results(self, full_results, claude_local_files_path):
+        """Save complete result set for Claude if configured"""
+        if not claude_local_files_path:
+            return None
+
+        def serialize_row(row):
+            return [self._format_value(val) for val in row]
+
+        data = [serialize_row(row) for row in full_results]
+        file_hash = hashlib.sha256(json.dumps(data).encode()).hexdigest()
+        file_name = f"{file_hash}.json"
+
+        with open(os.path.join(claude_local_files_path, file_name), 'w') as f:
+            data_str = json.dumps(data)
+
+            f.write(data_str)
+
+        result = SAVED_CLAUDE_RESULT.replace(SAVED_CLAUDE_FILE_NAME_PLACEHOLDER, file_name)
+
+        return result
+
+    @staticmethod
+    def _format_value(val) -> str:
+        """Format a value for display, handling None and datetime types"""
+        if val is None:
+            return "NULL"
+        if isinstance(val, (datetime, date)):
+            return val.isoformat()
+        return str(val)
+
+    @staticmethod
+    def _format_single_schema_response(data: dict):
+        table_name = data.get("name")
+        columns = data.get("columns")
+        foreign_keys = data.get("foreign_keys")
+        primary_keys = data.get("primary_keys")
+
+        result = [f"{table_name}:"]
+
+        # Process columns
+        for column in columns:
+            if "comment" in column:
+                del column["comment"]
+
+            name = column.pop("name")
+
+            column_parts = []
+
+            if name in primary_keys:
+                column_parts.append("primary key")
+
+            column_parts.append(str(column.pop("type")))
+
+            for key, value in column.items():
+                if value:
+                    if key in SHOW_KEY_ONLY:
+                        column_parts.append(key)
+
+                    else:
+                        column_parts.append(f"{key}={value}")
+
+            column_parts_str = ", ".join(column_parts)
+
+            result.append(f"    {name}: {column_parts_str}")
+
+        # Process relationships
+        if foreign_keys:
+            result.extend(["", "    Relationships:"])
+
+            for fk in foreign_keys:
+                constrained_columns = fk['constrained_columns']
+                referred_table = fk['referred_table']
+                referred_columns = fk['referred_columns']
+
+                constrained_columns_str = ", ".join(constrained_columns)
+                referred_columns_str = ", ".join(referred_columns)
+
+                result.append(f"      {constrained_columns_str} -> {referred_table}.{referred_columns_str}")
+
+        return "\n".join(result)

--- a/mcp_alchemy/server.py
+++ b/mcp_alchemy/server.py
@@ -19,7 +19,7 @@ IS_ENTRYPOINT = __name__ == "__main__"
 
 ARGS = MCPServerArguments.load(IS_ENTRYPOINT)
 
-mcp = FastMCP(ARGS.name, host=ARGS.host, port=ARGS.port, debug=ARGS.debug)
+mcp = FastMCP(ARGS.name, host=ARGS.host, port=ARGS.port, debug=ARGS.debug, stateless_http=ARGS.stateless_http)
 
 logger.info(f"Starting MCP Alchemy [{ARGS.name}], Version: {VERSION}")
 logger.info(f"Transport: {ARGS.transport}")

--- a/mcp_alchemy/server.py
+++ b/mcp_alchemy/server.py
@@ -1,260 +1,103 @@
-import os, json, hashlib
-from datetime import datetime, date
+import threading
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp import FastMCP, Context
 from mcp.server.fastmcp.utilities.logging import get_logger
 
-from sqlalchemy import create_engine, inspect, text
-
-### Helpers ###
+from mcp_alchemy.mcp_args import MCPServerArguments
+from mcp_alchemy.mcp_tools import MCPTool
+from mcp_alchemy.request_context import RequestContext, SUPPORTED_HEADERS, SUPPORTED_ENV_VARS
+from mcp_alchemy.response_formatter import ResponseFormatter
 
 def tests_set_global(k, v):
     globals()[k] = v
 
-### Database ###
+VERSION = "2025.10.21.94000"
 
 logger = get_logger(__name__)
-ENGINE = None
 
-def create_new_engine():
-    """Create engine with MCP-optimized settings to handle long-running connections"""
-    db_engine_options = os.environ.get('DB_ENGINE_OPTIONS')
-    user_options = json.loads(db_engine_options) if db_engine_options else {}
+IS_ENTRYPOINT = __name__ == "__main__"
 
-    # MCP-optimized defaults that can be overridden by user
-    options = {
-        'isolation_level': 'AUTOCOMMIT',
-        # Test connections before use (handles MySQL 8hr timeout, network drops)
-        'pool_pre_ping': True,
-        # Keep minimal connections (MCP typically handles one request at a time)
-        'pool_size': 1,
-        # Allow temporary burst capacity for edge cases
-        'max_overflow': 2,
-        # Force refresh connections older than 1hr (well under MySQL's 8hr default)
-        'pool_recycle': 3600,
-        # User can override any of the above
-        **user_options
-    }
+ARGS = MCPServerArguments.load(IS_ENTRYPOINT)
 
-    return create_engine(os.environ['DB_URL'], **options)
+mcp = FastMCP(ARGS.name, host=ARGS.host, port=ARGS.port, debug=ARGS.debug)
 
-def get_connection():
-    global ENGINE
+logger.info(f"Starting MCP Alchemy [{ARGS.name}], Version: {VERSION}")
+logger.info(f"Transport: {ARGS.transport}")
+logger.info(f"DB Context clean interval (seconds): {ARGS.close_unused_connections_interval}")
 
-    try:
-        try:
-            if ENGINE is None:
-                ENGINE = create_new_engine()
+if ARGS.transport != "stdio":
+    logger.info(f"Host: {ARGS.host}, Port: {ARGS.port}")
 
-            connection = ENGINE.connect()
+if ARGS.transport == "streamable-http":
+    logger.info(f"Expected headers: {list(SUPPORTED_HEADERS.keys())}")
 
-            # Set version variable for databases that support it
-            try:
-                connection.execute(text(f"SET @mcp_alchemy_version = '{VERSION}'"))
-            except Exception:
-                # Some databases don't support session variables
-                pass
+else:
+    logger.info(f"Expected environment variables: {SUPPORTED_ENV_VARS}")
 
-            return connection
+if ARGS.debug:
+    logger.info(f"Running in debug mode")
 
-        except Exception as e:
-            logger.warning(f"First connection attempt failed: {e}")
 
-            # Database might have restarted or network dropped - start fresh
-            if ENGINE is not None:
-                try:
-                    ENGINE.dispose()
-                except Exception:
-                    pass
+@mcp.tool(description=MCPTool.all_table_names.to_description())
+def all_table_names(ctx: Context | None = None) -> str:
+    logger.info("Retrieving all table names")
 
-            # One retry with fresh engine handles most transient failures
-            ENGINE = create_new_engine()
-            connection = ENGINE.connect()
+    request_context = RequestContext.load(ctx)
 
-            return connection
+    all_tables = request_context.db_context.get_tables()
 
-    except Exception as e:
-        logger.exception("Failed to get database connection after retry")
-        raise
+    logger.info(f"{len(all_tables):,.0f} table available")
 
-def get_db_info():
-    with get_connection() as conn:
-        engine = conn.engine
-        url = engine.url
-        result = [
-            f"Connected to {engine.dialect.name}",
-            f"version {'.'.join(str(x) for x in engine.dialect.server_version_info)}",
-            f"database {url.database}",
-        ]
+    result = ", ".join(all_tables)
 
-        if url.host:
-            result.append(f"on {url.host}")
+    return result
 
-        if url.username:
-            result.append(f"as user {url.username}")
+@mcp.tool(description=MCPTool.filter_table_names.to_description())
+def filter_table_names(q: str, ctx: Context | None = None) -> str:
+    request_context = RequestContext.load(ctx)
 
-        return " ".join(result) + "."
+    query = request_context.get_parameter("q", q)
 
-### Constants ###
+    logger.info(f"Retrieving all table names containing '{query}'")
 
-VERSION = "2025.8.15.91819"
-DB_INFO = get_db_info()
-EXECUTE_QUERY_MAX_CHARS = int(os.environ.get('EXECUTE_QUERY_MAX_CHARS', 4000))
-CLAUDE_LOCAL_FILES_PATH = os.environ.get('CLAUDE_LOCAL_FILES_PATH')
+    filtered_tables = request_context.db_context.get_tables(query)
 
-### MCP ###
+    logger.info(f"{len(filtered_tables):,.0f} table names containing '{query}'")
 
-mcp = FastMCP("MCP Alchemy")
-get_logger(__name__).info(f"Starting MCP Alchemy version {VERSION}")
+    result = ", ".join(filtered_tables)
 
-@mcp.tool(description=f"Return all table names in the database separated by comma. {DB_INFO}")
-def all_table_names() -> str:
-    with get_connection() as conn:
-        inspector = inspect(conn)
-        return ", ".join(inspector.get_table_names())
+    return result
 
-@mcp.tool(
-    description=f"Return all table names in the database containing the substring 'q' separated by comma. {DB_INFO}"
-)
-def filter_table_names(q: str) -> str:
-    with get_connection() as conn:
-        inspector = inspect(conn)
-        return ", ".join(x for x in inspector.get_table_names() if q in x)
 
-@mcp.tool(description=f"Returns schema and relation information for the given tables. {DB_INFO}")
-def schema_definitions(table_names: list[str]) -> str:
-    def format(inspector, table_name):
-        columns = inspector.get_columns(table_name)
-        foreign_keys = inspector.get_foreign_keys(table_name)
-        primary_keys = set(inspector.get_pk_constraint(table_name)["constrained_columns"])
-        result = [f"{table_name}:"]
+@mcp.tool(description=MCPTool.schema_definitions.to_description())
+async def schema_definitions(table_names: list[str], ctx: Context | None = None) -> str:
+    request_context = RequestContext.load(ctx)
 
-        # Process columns
-        show_key_only = {"nullable", "autoincrement"}
-        for column in columns:
-            if "comment" in column:
-                del column["comment"]
-            name = column.pop("name")
-            column_parts = (["primary key"] if name in primary_keys else []) + [str(
-                column.pop("type"))] + [k if k in show_key_only else f"{k}={v}" for k, v in column.items() if v]
-            result.append(f"    {name}: " + ", ".join(column_parts))
+    response_parser = ResponseFormatter(request_context)
 
-        # Process relationships
-        if foreign_keys:
-            result.extend(["", "    Relationships:"])
-            for fk in foreign_keys:
-                constrained_columns = ", ".join(fk['constrained_columns'])
-                referred_table = fk['referred_table']
-                referred_columns = ", ".join(fk['referred_columns'])
-                result.append(f"      {constrained_columns} -> {referred_table}.{referred_columns}")
+    result = response_parser.get_schema_list_response(table_names)
 
-        return "\n".join(result)
+    return result
 
-    with get_connection() as conn:
-        inspector = inspect(conn)
-        return "\n".join(format(inspector, table_name) for table_name in table_names)
+@mcp.tool(description=MCPTool.execute_query.to_description())
+async def execute_query(query: str, params, ctx: Context | None = None) -> str:
+    request_context = RequestContext.load(ctx)
 
-def execute_query_description():
-    parts = [
-        f"Execute a SQL query and return results in a readable format. Results will be truncated after {EXECUTE_QUERY_MAX_CHARS} characters."
-    ]
-    if CLAUDE_LOCAL_FILES_PATH:
-        parts.append("Claude Desktop may fetch the full result set via an url for analysis and artifacts.")
-    parts.append(
-        "IMPORTANT: You MUST use the params parameter for query parameter substitution (e.g. 'WHERE id = :id' with "
-        "params={'id': 123}) to prevent SQL injection. Direct string concatenation is a serious security risk.")
-    parts.append(DB_INFO)
-    return " ".join(parts)
+    response_parser = ResponseFormatter(request_context)
 
-@mcp.tool(description=execute_query_description())
-def execute_query(query: str, params: dict = {}) -> str:
-    def format_value(val):
-        """Format a value for display, handling None and datetime types"""
-        if val is None:
-            return "NULL"
-        if isinstance(val, (datetime, date)):
-            return val.isoformat()
-        return str(val)
+    result = response_parser.get_execute_query_response(query, params)
 
-    def format_result(cursor_result):
-        """Format rows in a clean vertical format"""
-        result, full_results = [], []
-        size, i, did_truncate = 0, 0, False
-
-        i = 0
-        while row := cursor_result.fetchone():
-            i += 1
-            if CLAUDE_LOCAL_FILES_PATH:
-                full_results.append(row)
-            if did_truncate:
-                continue
-
-            sub_result = []
-            sub_result.append(f"{i}. row")
-            for col, val in zip(cursor_result.keys(), row):
-                sub_result.append(f"{col}: {format_value(val)}")
-
-            sub_result.append("")
-
-            size += sum(len(x) + 1 for x in sub_result)  # +1 is for line endings
-
-            if size > EXECUTE_QUERY_MAX_CHARS:
-                did_truncate = True
-                if not CLAUDE_LOCAL_FILES_PATH:
-                    break
-            else:
-                result.extend(sub_result)
-
-        if i == 0:
-            return ["No rows returned"], full_results
-        elif did_truncate:
-            if CLAUDE_LOCAL_FILES_PATH:
-                result.append(f"Result: {i} rows (output truncated)")
-            else:
-                result.append(f"Result: showing first {i-1} rows (output truncated)")
-            return result, full_results
-        else:
-            result.append(f"Result: {i} rows")
-            return result, full_results
-
-    def save_full_results(full_results):
-        """Save complete result set for Claude if configured"""
-        if not CLAUDE_LOCAL_FILES_PATH:
-            return None
-
-        def serialize_row(row):
-            return [format_value(val) for val in row]
-
-        data = [serialize_row(row) for row in full_results]
-        file_hash = hashlib.sha256(json.dumps(data).encode()).hexdigest()
-        file_name = f"{file_hash}.json"
-
-        with open(os.path.join(CLAUDE_LOCAL_FILES_PATH, file_name), 'w') as f:
-            json.dump(data, f)
-
-        return (
-            f"Full result set url: https://cdn.jsdelivr.net/pyodide/claude-local-files/{file_name}"
-            " (format: [[row1_value1, row1_value2, ...], [row2_value1, row2_value2, ...], ...]])"
-            " (ALWAYS prefer fetching this url in artifacts instead of hardcoding the values if at all possible)")
-
-    try:
-        with get_connection() as connection:
-            cursor_result = connection.execute(text(query), params)
-
-            if not cursor_result.returns_rows:
-                return f"Success: {cursor_result.rowcount} rows affected"
-
-            output, full_results = format_result(cursor_result)
-
-            if full_results_message := save_full_results(full_results):
-                output.append(full_results_message)
-
-            return "\n".join(output)
-    except Exception as e:
-        return f"Error: {str(e)}"
+    return result
 
 def main():
-    mcp.run()
+    unused_connection_cleaner_thread = threading.Thread(
+        target=RequestContext.dispose_unused_connections,
+        daemon=True
+    )
 
-if __name__ == "__main__":
+    unused_connection_cleaner_thread.start()
+
+    mcp.run(transport=ARGS.transport)
+
+if IS_ENTRYPOINT:
     main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "A MCP server that connects to your database"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "mcp[cli]>=1.2.0rc1",
+    "mcp[cli]>=1.18,<2",
     "sqlalchemy>=2.0.36",
 ]
 authors = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+# Core dependencies for MCP Alchemy
+mcp[cli]>=1.18,<2
+sqlalchemy>=2.0.36
+
+# Development dependencies (optional)
+# Uncomment the following lines if you need to build/package the project
+# build>=1.2.2.post1
+# hatchling>=1.27.0
+
+starlette~=0.48.0
+


### PR DESCRIPTION
Major refactor to support streamable http and sse as stateless service:
- break down server.py into 3 main classes and 2 helpers for parsing args of cli
  - database_context - responsible for the communication with the database
  - request_context - responsible to handle tool call - extract parameters, manage singletone db context dictionary (multiple users can access, each of them multiple database connections).
  - response_formatter - responsible to format the responses for more complex tools such as schema details and execute query.
- server.py extracts the input args to support more functionality:

| Name                                | Description                                          | Type | Default     | Comments                                                                                                           |
|-------------------------------------|------------------------------------------------------|------|-------------|--------------------------------------------------------------------------------------------------------------------|
| --name                              | Name for the MCP Server (in logs)                    | str  | MCP Alchemy |                                                                                                                    |
| --host                              | Host for the MCP Server                              | str  | 127.0.0.1   | Relevant for SSE / Streamable-HTTP, If not set for those transport layers - will be accessible only from localhost |
| --port                              | Port for the MCP Server                              | int  | 8000        | relevant for SSE / Streamable-HTTP                                                                                 |
| --transport                         | Which transport layer to use                         | str  | stdio       | Options - ["stdio", "sse", "streamable-http"]                                                                      |
| --debug                             | Run with debug logs                                  | bool | False       |                                                                                                                    |
| --close-unused-connections-interval | Interval to check if DB connection is not being used | int | 600         | In seconds                                                                                                         |

More details:
- Tested in all 3 transport methods, all 4 tools with 2 different database types - Vertica and MariaDB
- Added logs for more details - initialization of MCP Server will present input parameters
- Added logs to DB connectivity and fix logging message when it fails to connect
- Since now it supports multiple users with multiplex databases, added machinsm to clean unused connections
- Updated README with section of how to use as remote MCP

Related to issue #33 